### PR TITLE
fix: Resolve broken links in Docusaurus documentation

### DIFF
--- a/docs/blog/2019-05-28-first-blog-post.md
+++ b/docs/blog/2019-05-28-first-blog-post.md
@@ -35,4 +35,4 @@ This automatically generates OpenAPI 3.0 specifications at `/v3/api-docs` and pr
 ✅ **Developer Experience** - Easy to explore and understand APIs  
 ✅ **CI/CD Integration** - Deployed automatically with GitHub Actions
 
-Check out our [API Documentation](/docs/xml-sanitizer/api) to see it in action!
+Check out our [API Documentation](/xml-sanitizer/overview) to see it in action!

--- a/docs/docs/architecture/overview.md
+++ b/docs/docs/architecture/overview.md
@@ -197,6 +197,9 @@ Both services expose Spring Boot Actuator endpoints:
 
 ## Next Steps
 
-- [Deployment Guide](/docs/deployment/local-development)
-- [Configuration Reference](/docs/guides/configuration)
-- [ISO 20022 Integration](/docs/guides/iso20022)
+## Next Steps
+
+- [Getting Started](/guides/getting-started)
+- [Intelligent Mapping Generator](/intelligent-mapping-generator/overview)
+- [XML Sanitizer](/xml-sanitizer/overview)
+- [Back to Overview](/intro)

--- a/docs/docs/guides/getting-started.md
+++ b/docs/docs/guides/getting-started.md
@@ -237,12 +237,13 @@ export JAVA_HOME=/path/to/java21
 
 ## Next Steps
 
-Now that your environment is set up:
+Congratulations! 🎉 You now have the services running locally.
 
-- 📘 [Explore the Architecture](/docs/architecture/overview)
-- 🔌 [Read the API Documentation](/docs/xml-sanitizer/overview)
-- 🚀 [Learn about Deployment](/docs/deployment/local-development)
-- 📝 [Contributing Guidelines](/docs/guides/contributing)
+Continue with:
+- [System Architecture](/architecture/overview)
+- [Intelligent Mapping Generator](/intelligent-mapping-generator/overview)
+- [XML Sanitizer](/xml-sanitizer/overview)
+- [Back to Overview](/intro)
 
 ## Need Help?
 

--- a/docs/docs/intelligent-mapping-generator/overview.md
+++ b/docs/docs/intelligent-mapping-generator/overview.md
@@ -124,7 +124,7 @@ implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
 ## Next Steps
 
-- [API Reference](/docs/intelligent-mapping-generator/api) - Complete API documentation
-- [ISO 20022 Guide](/docs/guides/iso20022) - Working with ISO 20022 messages
-- [ActiveMQ Configuration](/docs/intelligent-mapping-generator/artemis) - Message broker setup
-- [Examples](/docs/intelligent-mapping-generator/examples) - Usage examples
+- [Getting Started](/guides/getting-started)
+- [System Architecture](/architecture/overview)
+- [XML Sanitizer](/xml-sanitizer/overview)
+- [Back to Overview](/intro)

--- a/docs/docs/xml-sanitizer/overview.md
+++ b/docs/docs/xml-sanitizer/overview.md
@@ -74,6 +74,7 @@ java -jar xml-sanitizer/build/libs/xml-sanitizer-0.0.1-SNAPSHOT.jar
 
 ## Next Steps
 
-- [API Reference](/docs/xml-sanitizer/api) - Complete API documentation
-- [Configuration Guide](/docs/xml-sanitizer/configuration) - Advanced configuration
-- [Examples](/docs/xml-sanitizer/examples) - Usage examples
+- [Getting Started](/guides/getting-started)
+- [System Architecture](/architecture/overview)
+- [Intelligent Mapping Generator](/intelligent-mapping-generator/overview)
+- [Back to Overview](/intro)

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -20,8 +20,8 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/intro">
-            Docusaurus Tutorial - 5min ⏱️
+            to="/intro">
+            Get Started 🚀
           </Link>
         </div>
       </div>


### PR DESCRIPTION
- Update all /docs/intro links to /intro (correct path)
- Remove links to non-existent pages (api, configuration, examples, etc.)
- Replace broken references with links to existing pages
- Update homepage button text and link
- Fix blog post API documentation link