### PR TITLE
fix: Correct all documentation links with /docs/ prefix

### DIFF
--- a/docs/blog/2019-05-28-first-blog-post.md
+++ b/docs/blog/2019-05-28-first-blog-post.md
@@ -35,4 +35,4 @@ This automatically generates OpenAPI 3.0 specifications at `/v3/api-docs` and pr
 ✅ **Developer Experience** - Easy to explore and understand APIs  
 ✅ **CI/CD Integration** - Deployed automatically with GitHub Actions
 
-Check out our [API Documentation](/xml-sanitizer/overview) to see it in action!
+Check out our [API Documentation](/docs/xml-sanitizer/overview) to see it in action!

--- a/docs/docs/architecture/overview.md
+++ b/docs/docs/architecture/overview.md
@@ -199,7 +199,7 @@ Both services expose Spring Boot Actuator endpoints:
 
 ## Next Steps
 
-- [Getting Started](/guides/getting-started)
-- [Intelligent Mapping Generator](/intelligent-mapping-generator/overview)
-- [XML Sanitizer](/xml-sanitizer/overview)
-- [Back to Overview](/intro)
+- [Getting Started](/docs/guides/getting-started)
+- [Intelligent Mapping Generator](/docs/intelligent-mapping-generator/overview)
+- [XML Sanitizer](/docs/xml-sanitizer/overview)
+- [Back to Overview](/)

--- a/docs/docs/guides/getting-started.md
+++ b/docs/docs/guides/getting-started.md
@@ -148,10 +148,35 @@ Expected response:
 
 ### Access Swagger UI
 
-Open in your browser:
+Open your browser and visit:
 
-- **XML Sanitizer**: [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html)
-- **Mapping Generator**: [http://localhost:8081/swagger-ui.html](http://localhost:8081/swagger-ui.html)
+- **XML Sanitizer**: http://localhost:8080/swagger-ui.html
+- **Mapping Generator**: http://localhost:8081/swagger-ui.html
+
+## Running Documentation Locally
+
+To run this documentation site locally for development:
+
+### Install Dependencies
+```bash
+cd /Users/ejikeudeze/AI_Projects/fintech-mapping-features/docs
+npm install
+```
+
+### Start Development Server
+```bash
+cd /Users/ejikeudeze/AI_Projects/fintech-mapping-features/docs && npm start
+```
+
+The documentation site will open at: http://localhost:3000/fintech-mapping-features/
+
+### Build for Production
+```bash
+cd docs
+npm run build
+```
+
+The static files will be generated in the `docs/build` directory.
 
 ## Testing the APIs
 
@@ -240,10 +265,10 @@ export JAVA_HOME=/path/to/java21
 Congratulations! 🎉 You now have the services running locally.
 
 Continue with:
-- [System Architecture](/architecture/overview)
-- [Intelligent Mapping Generator](/intelligent-mapping-generator/overview)
-- [XML Sanitizer](/xml-sanitizer/overview)
-- [Back to Overview](/intro)
+- [System Architecture](/docs/architecture/overview)
+- [Intelligent Mapping Generator](/docs/intelligent-mapping-generator/overview)
+- [XML Sanitizer](/docs/xml-sanitizer/overview)
+- [Back to Overview](/)
 
 ## Need Help?
 

--- a/docs/docs/intelligent-mapping-generator/overview.md
+++ b/docs/docs/intelligent-mapping-generator/overview.md
@@ -124,7 +124,7 @@ implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
 ## Next Steps
 
-- [Getting Started](/guides/getting-started)
-- [System Architecture](/architecture/overview)
-- [XML Sanitizer](/xml-sanitizer/overview)
-- [Back to Overview](/intro)
+- [Getting Started](/docs/guides/getting-started)
+- [System Architecture](/docs/architecture/overview)
+- [XML Sanitizer](/docs/xml-sanitizer/overview)
+- [Back to Overview](/)

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -57,3 +57,18 @@ Each microservice provides interactive API documentation via Swagger UI:
 
 - **XML Sanitizer**: [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html)
 - **Mapping Generator**: [http://localhost:8081/swagger-ui.html](http://localhost:8081/swagger-ui.html)
+
+## 📖 Running This Documentation Site Locally
+
+To run this documentation website on your local machine:
+
+```bash
+cd /Users/ejikeudeze/AI_Projects/fintech-mapping-features/docs && npm start
+```
+
+The site will be available at: [http://localhost:3000/fintech-mapping-features/](http://localhost:3000/fintech-mapping-features/)
+
+### Build Documentation for Production
+```bash
+cd docs && npm run build
+```

--- a/docs/docs/xml-sanitizer/overview.md
+++ b/docs/docs/xml-sanitizer/overview.md
@@ -74,7 +74,7 @@ java -jar xml-sanitizer/build/libs/xml-sanitizer-0.0.1-SNAPSHOT.jar
 
 ## Next Steps
 
-- [Getting Started](/guides/getting-started)
-- [System Architecture](/architecture/overview)
-- [Intelligent Mapping Generator](/intelligent-mapping-generator/overview)
-- [Back to Overview](/intro)
+- [Getting Started](/docs/guides/getting-started)
+- [System Architecture](/docs/architecture/overview)
+- [Intelligent Mapping Generator](/docs/intelligent-mapping-generator/overview)
+- [Back to Overview](/)

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -20,7 +20,7 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/intro">
+            to="/docs/">
             Get Started 🚀
           </Link>
         </div>


### PR DESCRIPTION
- Update all internal doc links to use /docs/ prefix
- Change /intro links to / (root path with slug)
- Fix homepage button to link to /docs/
- Fix blog post API documentation link
- Add npm start command documentation for local development