### PR TITLE
fix: resolve broken links in Docusaurus documentation

### DIFF
--- a/docs/docs/architecture/overview.md
+++ b/docs/docs/architecture/overview.md
@@ -197,9 +197,7 @@ Both services expose Spring Boot Actuator endpoints:
 
 ## Next Steps
 
-## Next Steps
-
-- [Getting Started](/docs/guides/getting-started)
-- [Intelligent Mapping Generator](/docs/intelligent-mapping-generator/overview)
-- [XML Sanitizer](/docs/xml-sanitizer/overview)
+- [Getting Started](../guides/getting-started)
+- [Intelligent Mapping Generator](../intelligent-mapping-generator/overview)
+- [XML Sanitizer](../xml-sanitizer/overview)
 - [Back to Overview](/)

--- a/docs/docs/guides/getting-started.md
+++ b/docs/docs/guides/getting-started.md
@@ -265,12 +265,11 @@ export JAVA_HOME=/path/to/java21
 Congratulations! 🎉 You now have the services running locally.
 
 Continue with:
-- [System Architecture](/docs/architecture/overview)
-- [Intelligent Mapping Generator](/docs/intelligent-mapping-generator/overview)
-- [XML Sanitizer](/docs/xml-sanitizer/overview)
+- [System Architecture](../architecture/overview)
+- [Intelligent Mapping Generator](../intelligent-mapping-generator/overview)
+- [XML Sanitizer](../xml-sanitizer/overview)
 - [Back to Overview](/)
 
 ## Need Help?
 
-- Check the [Troubleshooting Guide](/docs/guides/troubleshooting)
 - Open an issue on [GitHub](https://github.com/Ejyke90/fintech-mapping-features/issues)

--- a/docs/docs/intelligent-mapping-generator/overview.md
+++ b/docs/docs/intelligent-mapping-generator/overview.md
@@ -124,7 +124,7 @@ implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
 ## Next Steps
 
-- [Getting Started](/docs/guides/getting-started)
-- [System Architecture](/docs/architecture/overview)
-- [XML Sanitizer](/docs/xml-sanitizer/overview)
+- [Getting Started](../guides/getting-started)
+- [System Architecture](../architecture/overview)
+- [XML Sanitizer](../xml-sanitizer/overview)
 - [Back to Overview](/)

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -14,7 +14,7 @@ This project is a multi-module Spring Boot monorepo for fintech operations:
 ### 1. Intelligent Mapping Generator (Port 8081) ✅ **Active**
 Generates intelligent mappings for fintech data transformations with ISO 20022 support and ActiveMQ Artemis integration.
 
-[View Mapping Generator Documentation →](/docs/intelligent-mapping-generator/overview)
+[View Mapping Generator Documentation →](docs/intelligent-mapping-generator/overview)
 
 ### 2. XML Sanitizer (Port 8080) 🚧 **Planned**
 Future module that will sanitize XML payloads by removing invalid characters and ensuring XML compliance.

--- a/docs/docs/xml-sanitizer/overview.md
+++ b/docs/docs/xml-sanitizer/overview.md
@@ -48,7 +48,7 @@ curl -X POST http://localhost:8080/sanitize-chars \
 
 ## API Endpoints
 
-The service exposes RESTful endpoints for XML sanitization. See the [API Reference](/docs/xml-sanitizer/api) for complete documentation.
+The service exposes RESTful endpoints for XML sanitization. API documentation will be available at `/swagger-ui.html` when the service is running.
 
 ## Configuration
 
@@ -74,7 +74,7 @@ java -jar xml-sanitizer/build/libs/xml-sanitizer-0.0.1-SNAPSHOT.jar
 
 ## Next Steps
 
-- [Getting Started](/docs/guides/getting-started)
-- [System Architecture](/docs/architecture/overview)
-- [Intelligent Mapping Generator](/docs/intelligent-mapping-generator/overview)
+- [Getting Started](../guides/getting-started)
+- [System Architecture](../architecture/overview)
+- [Intelligent Mapping Generator](../intelligent-mapping-generator/overview)
 - [Back to Overview](/)


### PR DESCRIPTION
- Fixed absolute paths to use relative paths throughout all docs
- Removed reference to non-existent troubleshooting guide
- Removed broken link to xml-sanitizer/api (not yet generated)
- Fixed intro.md link to intelligent-mapping-generator
- Fixed duplicate 'Next Steps' section in architecture/overview.md

This fixes the GitHub Actions build failure caused by broken links.