### PR TITLE
fix: resolve remaining broken links in Docusaurus

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -14,7 +14,7 @@ This project is a multi-module Spring Boot monorepo for fintech operations:
 ### 1. Intelligent Mapping Generator (Port 8081) ✅ **Active**
 Generates intelligent mappings for fintech data transformations with ISO 20022 support and ActiveMQ Artemis integration.
 
-[View Mapping Generator Documentation →](docs/intelligent-mapping-generator/overview)
+[View Mapping Generator Documentation →](/docs/intelligent-mapping-generator/overview)
 
 ### 2. XML Sanitizer (Port 8080) 🚧 **Planned**
 Future module that will sanitize XML payloads by removing invalid characters and ensuring XML compliance.

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -143,8 +143,8 @@ const config: Config = {
           title: 'Docs',
           items: [
             {
-              label: 'Tutorial',
-              to: '/docs/intro',
+              label: 'Getting Started',
+              to: '/',
             },
           ],
         },


### PR DESCRIPTION
- Fixed footer link from '/docs/intro' to '/' in docusaurus.config.ts
- Fixed intro.md link to use absolute path '/docs/...' instead of 'docs/...'
- Changed footer label from 'Tutorial' to 'Getting Started' for clarity
- Build now passes successfully with no broken links

Verified locally with: npm run build